### PR TITLE
remove die language

### DIFF
--- a/Wide_Format_Quick_Quote.php
+++ b/Wide_Format_Quick_Quote.php
@@ -1,5 +1,9 @@
 <?php
-$xml=simplexml_load_file("wide_format_paper.xml") or die("Error: Cannot create object");
+$xml = null;
+$xml = simplexml_load_file("wide_format_paper.xml");
+if ($xml == null) {
+	return;
+}
 ?>
 
 <html>


### PR DESCRIPTION
Per PHP Codesniffer, die language is discouraged. Returning null is used instead now.